### PR TITLE
Fix typo in hanami `params` example

### DIFF
--- a/source/peeks/_hanami.md
+++ b/source/peeks/_hanami.md
@@ -11,7 +11,7 @@ module API::Controllers::Posts
     deserializable_resource :post
 
     params do
-      require(:post).schema do
+      required(:post).schema do
         required(:title)
         required(:content)
         required(:tag_ids)


### PR DESCRIPTION
The documentation for defining a hanami params validation calls `require` instead of `required` which causes an error.