### PR TITLE
Use root-relative URL for favicon

### DIFF
--- a/source/_head.erb
+++ b/source/_head.erb
@@ -3,7 +3,7 @@
     <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
     <meta name="description" content="Ruby library for efficiently building and consuming JSON API documents, with Rails and Hanami integrations.">
     <meta name="keywords" content="JSONAPI jsonapi JSON API ruby library rails hanami resources efficient">
-    <link rel="icon" type="image/png" href="images/favicon.png" />
+    <link rel="icon" type="image/png" href="/images/favicon.png" />
 
     <title>jsonapi-rb | Efficiently build and consume JSON API documents.</title>
 


### PR DESCRIPTION
Relative URLs are resolved to full URLs using the base path of the current page, which means that the browser tries to request `/guides/getting_started/images/favicon.png` on `/guides/getting_started/hanami.html`. As the result, the favicon is currently displayed on the index and the "Contributors" pages only. The solution is to switch to root-relative URLs.

Another option is to use Padrino's [`favicon_tag`](http://www.rubydoc.info/github/padrino/padrino-framework/Padrino/Helpers/AssetTagHelpers:favicon_tag) (`<%= favicon_tag 'favicon.png' %>`) which generates the same markup.