### PR TITLE
Update guide links in serialization/index.html

### DIFF
--- a/guides/serialization/index.html
+++ b/guides/serialization/index.html
@@ -92,8 +92,9 @@ to the <em>renderer</em>, that will build the appropriate serializable resources
 render them into a JSON API document.</p>
 
 <ul>
-<li><a href="guides/serialization/defining.html">Defining serializable resources</a></li>
-<li><a href="guides/serialization/rendering.html">Rendering JSON API documents</a></li>
+  <li><a href="/guides/serialization/defining.html">Defining serializable resources</a></li>
+  <li><a href="/guides/serialization/rendering.html">Rendering JSON API documents</a></li>
+  <li><a href="/guides/serialization/errors.html">Rendering errors</a></li>
 </ul>
 
     </div>


### PR DESCRIPTION
Most importantly the the broken links to defining & rendering resources on the index were fixed.

Additionally the soon to come rendering errors link was added which is consistent with the sidebar navigation.