### PR TITLE
Fix broken links on serialization and deserialization index pages

### DIFF
--- a/source/guides/deserialization/index.html.md
+++ b/source/guides/deserialization/index.html.md
@@ -11,5 +11,5 @@ Once your deserializable resources are defined, you can call them on hashes
 representing input JSON API payloads, and obtain a hash that you can use
 directly to create/update your models.
 
-- [Defining deserializable resources](guides/deserialization/defining.html)
-- [Deserializing payloads](guides/deserialization/deserializing.html)
+- [Defining deserializable resources](/guides/deserialization/defining.html)
+- [Deserializing payloads](/guides/deserialization/deserializing.html)

--- a/source/guides/serialization/index.html.md
+++ b/source/guides/serialization/index.html.md
@@ -14,5 +14,5 @@ Once your serializable resources are defined, you can pass your business objects
 to the *renderer*, that will build the appropriate serializable resources, and
 render them into a JSON API document.
 
-- [Defining serializable resources](guides/serialization/defining.html)
-- [Rendering JSON API documents](guides/serialization/rendering.html)
+- [Defining serializable resources](/guides/serialization/defining.html)
+- [Rendering JSON API documents](/guides/serialization/rendering.html)


### PR DESCRIPTION
Attempting to fix #18 

The links are not actually broken when running the guides on a local server, but this change makes these links consistent with the ones in the sidebar, so hopefully it will fix the issue on the live site.